### PR TITLE
onCloseの修正部分です

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-function Modal(modalData, { onClose }) {
+function Modal({ modalData, onClose }) {
   console.log(modalData);
 
   return (
@@ -8,17 +8,17 @@ function Modal(modalData, { onClose }) {
       <div className="detaileContainer">
         <div className="detailItem">
           <div className="modalImg">
-            <img src={modalData.modalData.sprites.front_default} alt="#" />
-            <img src={modalData.modalData.sprites.back_default} alt="#" />
+            <img src={modalData.sprites.front_default} alt="#" />
+            <img src={modalData.sprites.back_default} alt="#" />
           </div>
-          <h3>{modalData.modalData.name}</h3>
+          <h3>{modalData.name}</h3>
           <p>
-            {modalData.modalData.abilities.map((ability) => {
+            {modalData.abilities.map((ability) => {
               return <div>{ability.ability.name}</div>;
             })}
           </p>
           <div className="tableStats"></div>
-          {modalData.modalData.stats.map((stat) => {
+          {modalData.stats.map((stat) => {
             return (
               <table>
                 <tr>


### PR DESCRIPTION
React のpropsは全て第一引数として辞書型で渡されますので、onCloseも第一引数で受け取る必要があります

以下の二つは値の取り出し方が違うだけで、やっていることは同じコードになります。
１個目の取り出し方は[分割代入](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)と言われています
```
function Modal({ modalData, onClose}) {

  return (
    <>
      <h3>{modalData.name}</h3>
      <button onClick={onClose}>close</button>
    </>  );
}
```

```
function Modal(props) {

  return (
    <>
      <h3>{props.modalData.name}</h3>
      <button onClick={props.onClose}>close</button>
    </>
  );
}